### PR TITLE
fix Kraken X3 value loading stuck

### DIFF
--- a/FanCtrl/Controller/HidUSBController.cs
+++ b/FanCtrl/Controller/HidUSBController.cs
@@ -26,6 +26,18 @@ namespace FanCtrl
         private List<byte[]> mSendArrayList = new List<byte[]>();
         private object mSendArrayListLock = new object();
 
+        private int mReadTimeout = -1;
+        public int ReadTimeout
+        {
+            get => mReadTimeout;
+            set
+            {
+                mReadTimeout = value;
+                if (mHidStream != null)
+                    mHidStream.ReadTimeout = mReadTimeout;
+            }
+        }
+
         public HidUSBController(USBVendorID vendorID, USBProductID productID) : base(vendorID, productID)
         {
 
@@ -71,6 +83,8 @@ namespace FanCtrl
                                 return false;
                             }
                             mIsOpen = true;
+                            if (mReadTimeout >= 0)
+                                mHidStream.ReadTimeout = mReadTimeout;
                             break;
                         }
                         i++;

--- a/FanCtrl/Hardware/Kraken.cs
+++ b/FanCtrl/Hardware/Kraken.cs
@@ -14,7 +14,7 @@ namespace FanCtrl
 {
     public class Kraken : USBDevice
     {
-        private const long SEND_DELAY_TIME = 5000;
+        private const long SEND_DELAY_TIME = 500;
 
         private int mLastLiquidTemp = 0;
         private int mLastFanRPM = 0;
@@ -83,6 +83,7 @@ namespace FanCtrl
             mFanLastSendTime = 0;
 
             mUSBController = new HidUSBController(USBVendorID.NZXT, productID);
+            ((HidUSBController)mUSBController).ReadTimeout = 5000;
             mUSBController.onRecvHandler += onRecv;
             if(mUSBController.start(index) == false)
             {


### PR DESCRIPTION
NZXT Kraken X3 계열 사용 중에 처음 얼마간은 정상적으로 온도, 펌프 속도를 가져오지만
어느 순간부터 더이상 갱신이 제대로 되지 않는 현상을 해결합니다.
SEND_DELAY_TIME을 임의로 500으로 줄였는데 확인하시기 바랍니다.