### PR TITLE
HidUSB auto reopen

### DIFF
--- a/FanCtrl/Controller/HidUSBController.cs
+++ b/FanCtrl/Controller/HidUSBController.cs
@@ -20,6 +20,7 @@ namespace FanCtrl
         private delegate void RecvDelegate();
         private delegate void SendDelegate();
 
+        private uint mIndex = 0;
         private bool mIsSend = false;
         private List<byte[]> mSendArrayList = new List<byte[]>();
         private object mSendArrayListLock = new object();
@@ -52,6 +53,7 @@ namespace FanCtrl
         {
             try
             {
+                mIndex = index;
                 uint i = 0;
                 int venderID = (int)this.VendorID;
                 int productID = (int)this.ProductID;
@@ -169,7 +171,14 @@ namespace FanCtrl
                     }
                 }
             }
-            catch { }
+            catch {
+                mSendArrayList.Clear();
+                mIsSend = false;
+                Monitor.Exit(mSendArrayListLock);
+                this.stop();
+                this.start(mIndex);
+                return;
+            }
             mSendArrayList.Clear();
             mIsSend = false;
             Monitor.Exit(mSendArrayListLock);


### PR DESCRIPTION
NZXT Kraken X3 계열 장치가 갑자기 연결이 끊겼다가 다시 연결되는 증상이 발생할 경우
온도/펌프 속도를 더이상 읽어올 수 없는 현상을 해결합니다.

대표적으로 리안리 L-connect와의 충돌로 인해 USB 연결이 끊어졌다 다시 붙는 증상이 수시로 발생할 수 있는데
이 때 문제 없이 동작하게 하기 위함입니다.