### PR TITLE
fix gigabyte stuck

### DIFF
--- a/FanCtrl/Hardware/Gigabyte.cs
+++ b/FanCtrl/Hardware/Gigabyte.cs
@@ -63,23 +63,26 @@ namespace FanCtrl
                 var temperatureList = new List<float>();
                 mGigabyteSmartGuardianFanControlModule.GetHardwareMonitorDatas(ref temperatureList, ref mGigabyteFanSpeedList);
 
-                var management = new GraphicsCardServiceManagement();
-                if (management.IsProcessExist() == true)
-                {
-                    mGigabyteGraphicsCardControlModule = new GraphicsCardControlModule();
-                    if (mGigabyteGraphicsCardControlModule.AmdGpuCount > 0)
+                try {
+                    var management = new GraphicsCardServiceManagement();
+                    if (management.IsProcessExist() == true)
                     {
-                        mGigabyteGraphicsCardControlModule.GetObjects(ref mGigabyteAmdRadeonGraphicsModuleList);
-                    }
-
-                    if (isNvAPIWrapper == false)
-                    {
-                        if (mGigabyteGraphicsCardControlModule.NvidiaGpuCount > 0)
+                        mGigabyteGraphicsCardControlModule = new GraphicsCardControlModule();
+                        if (mGigabyteGraphicsCardControlModule.AmdGpuCount > 0)
                         {
-                            mGigabyteGraphicsCardControlModule.GetObjects(ref mGigabyteNvidiaGeforceGraphicsModuleList);
+                            mGigabyteGraphicsCardControlModule.GetObjects(ref mGigabyteAmdRadeonGraphicsModuleList);
+                        }
+
+                        if (isNvAPIWrapper == false)
+                        {
+                            if (mGigabyteGraphicsCardControlModule.NvidiaGpuCount > 0)
+                            {
+                                mGigabyteGraphicsCardControlModule.GetObjects(ref mGigabyteNvidiaGeforceGraphicsModuleList);
+                            }
                         }
                     }
                 }
+                catch {}
 
                 this.unlockBus();
                 return true;
@@ -380,6 +383,8 @@ namespace FanCtrl
 
         private float onGetGigabyteFanSpeed(int index)
         {
+            if (mGigabyteFanSpeedList.Count <= index)
+                return 0;
             return mGigabyteFanSpeedList[index];
         }
 
@@ -412,6 +417,8 @@ namespace FanCtrl
 
         private float onGetGigabyteTemperature(int index)
         {
+            if (mGigabyteTemperatureList.Count <= index)
+                return 0;
             return mGigabyteTemperatureList[index];
         }
 


### PR DESCRIPTION
이유를 알 수 없는데, GIGABYTE 보드에서 GIGABYTE 설정을 킨 뒤 설정을 저장하면 바로 죽어버리고,
그 후 실행 할 때 마다 올바로 실행되지 않고 죽는 현상을 해결합니다.

AppCenter, EasyTuneEngineService, GraphicsCardEngine이 올바로 설치되어 있고, 실행 중임에도 불구하고 발생하며,
AppCenter, EasyTune을 제거해도 마찬가지로 발생합니다.

이 증상이 제게만 발생하는지 여부는 확인하지 못 했습니다.